### PR TITLE
Fix validator path combination bug

### DIFF
--- a/src/main/kotlin/validation/dsl/ValidationDsl.kt
+++ b/src/main/kotlin/validation/dsl/ValidationDsl.kt
@@ -46,7 +46,12 @@ fun <T> FieldValidationScope<T>.use(validator: Validator<T>) {
             is ValidationResult.Valid -> Validated.Valid(Unit)
             is ValidationResult.Invalid -> Validated.Invalid(
                 result.errors.map { error ->
-                    error.copy(path = path.child(error.path.toString()))
+                    val updatedPath = if (error.path == PropertyPath.EMPTY) {
+                        path
+                    } else {
+                        path.child(error.path.toString())
+                    }
+                    error.copy(path = updatedPath)
                 }
             )
         }

--- a/src/main/kotlin/validation/dsl/Validator.kt
+++ b/src/main/kotlin/validation/dsl/Validator.kt
@@ -7,6 +7,13 @@ import kotlin.reflect.KProperty1
 class Validator<T> {
     private val validations = mutableListOf<(T) -> Validated<Unit>>()
 
+    @ValidationDsl
+    fun root(block: FieldValidationScope<T>.() -> Unit) {
+        validations += { target ->
+            FieldValidationScope(PropertyPath.EMPTY) { target }.apply(block).evaluate()
+        }
+    }
+
     fun <R> validate(
         prop: KProperty1<T, R>,
         block: FieldValidationScope<R>.() -> Unit

--- a/src/test/kotlin/validation/dsl/ValidationDslTest.kt
+++ b/src/test/kotlin/validation/dsl/ValidationDslTest.kt
@@ -572,4 +572,25 @@ class ValidationDslTest {
         assertEquals("profile-checks", group)
     }
 
+    @Test
+    fun `use should handle root path errors`() {
+        data class Leaf(val value: String)
+        data class Wrapper(val leaf: Leaf)
+
+        val leafValidator = validator<Leaf> {
+            root {
+                rule("bad") { false }
+            }
+        }
+
+        val wrapperValidator = validator {
+            validate(Wrapper::leaf) {
+                use(leafValidator)
+            }
+        }
+
+        val result = wrapperValidator.validate(Wrapper(Leaf("x")))
+        result.assertError("leaf", "bad")
+    }
+
 }


### PR DESCRIPTION
## Summary
- fix path joining for nested validator errors
- add root validation helper
- rewrite root error test without `@Suppress` annotation

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683f78e1a034832ca37e7e31fd08a101