### PR TITLE
Add test for use mapping empty nested path

### DIFF
--- a/src/test/kotlin/validation/dsl/ValidationDslTest.kt
+++ b/src/test/kotlin/validation/dsl/ValidationDslTest.kt
@@ -593,4 +593,26 @@ class ValidationDslTest {
         result.assertError("leaf", "bad")
     }
 
+    @Test
+    fun `use should map empty nested error path to parent`() {
+        data class Leaf(val value: String)
+        data class Wrapper(val leaf: Leaf)
+
+        val leafValidator = validator<Leaf> {
+            root {
+                // add rule without path injection so it retains PropertyPath.EMPTY
+                this.rules += rule<Leaf>("bad") { false }
+            }
+        }
+
+        val wrapperValidator = validator {
+            validate(Wrapper::leaf) {
+                use(leafValidator)
+            }
+        }
+
+        val result = wrapperValidator.validate(Wrapper(Leaf("x")))
+        result.assertError("leaf", "bad")
+    }
+
 }

--- a/src/test/kotlin/validation/dsl/ValidationDslTest.kt
+++ b/src/test/kotlin/validation/dsl/ValidationDslTest.kt
@@ -488,7 +488,7 @@ class ValidationDslTest {
 
         val profileValidator = validator {
             validate(Profile::bio) {
-                rule("must not be blank") { it.isBlank() } // fail deliberately
+                rule("must not be blank") { it.isBlank() }
             }
         }
 
@@ -600,7 +600,6 @@ class ValidationDslTest {
 
         val leafValidator = validator<Leaf> {
             root {
-                // add rule without path injection so it retains PropertyPath.EMPTY
                 this.rules += rule<Leaf>("bad") { false }
             }
         }


### PR DESCRIPTION
## Summary
- add test to ensure nested validator using a rule with an empty error path is mapped to the parent property when used

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683f81bb236c832cbe1c449ecd332ec2