### PR TITLE
Add test for map invalid branch

### DIFF
--- a/src/test/kotlin/validation/core/ValidationResultTest.kt
+++ b/src/test/kotlin/validation/core/ValidationResultTest.kt
@@ -70,6 +70,17 @@ class ValidationResultTest {
     }
 
     @Test
+    fun `ValidationResult map does not run when invalid`() {
+        val error = ValidationError(PropertyPath("x"), "bad")
+        val result = ValidationResult.from("ignored", listOf(error))
+        var called = false
+        val mapped = result.map { called = true; it.length }
+        assertFalse(called)
+        assertTrue(mapped is ValidationResult.Invalid)
+        assertEquals(listOf(error), (mapped as ValidationResult.Invalid).errors)
+    }
+
+    @Test
     fun `ValidationResult flatMap chains valid results`() {
         val result = ValidationResult.Valid("foo")
         val mapped = result.flatMap { ValidationResult.Valid(it.length) }


### PR DESCRIPTION
## Summary
- add coverage for `map` when the `ValidationResult` is invalid

## Testing
- `gradle test` *(fails: plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f92ef5e78832cbf20be8d84b62bef